### PR TITLE
Use builtin Title and Description

### DIFF
--- a/partials/about.hbs
+++ b/partials/about.hbs
@@ -1,8 +1,12 @@
 <summary class="about">
     <p>
-        Lorem ipsum...
+      {{#if @blog.logo}}
+          <img class="site-logo" src="{{@blog.logo}}" alt="{{@blog.title}}" />
+      {{else}}
+          {{@blog.title}}
+      {{/if}}
     </p>
     <p>
-        Lorem ipsum...
+        {{@blog.description}}
     </p>
 </summary>


### PR DESCRIPTION
Use builtin Title and Description from Ghost admin page instead of manually filling in to partials/about.hbs